### PR TITLE
[DeviceDetailsViewController] Major UI updates

### DIFF
--- a/PiRemote/DeviceSetup.storyboard
+++ b/PiRemote/DeviceSetup.storyboard
@@ -8,8 +8,8 @@
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11757"/>
         <capability name="Alignment constraints to the first baseline" minToolsVersion="6.0"/>
         <capability name="Alignment constraints with different attributes" minToolsVersion="5.1"/>
-        <capability name="Aspect ratio constraints" minToolsVersion="5.1"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
+        <capability name="Constraints with non-1.0 multipliers" minToolsVersion="5.1"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -22,75 +22,99 @@
                         <viewControllerLayoutGuide type="bottom" id="KUK-UL-XM6"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="dTS-dG-j8M">
-                        <rect key="frame" x="0.0" y="0.0" width="150" height="250"/>
+                        <rect key="frame" x="0.0" y="0.0" width="160" height="320"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Pin Name" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="n2g-c0-oaU">
-                                <rect key="frame" x="16" y="44.5" width="118" height="30"/>
+                                <rect key="frame" x="16" y="44.5" width="128" height="30"/>
                                 <nil key="textColor"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits"/>
                             </textField>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="GPIO #" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vbH-px-ScG">
-                                <rect key="frame" x="47.5" y="16" width="56.5" height="20.5"/>
+                                <rect key="frame" x="52" y="16" width="56.5" height="20.5"/>
                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="249" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ZcF-Ib-Hs1">
-                                <rect key="frame" x="0.0" y="105.5" width="150" height="45"/>
+                                <rect key="frame" x="0.0" y="105.5" width="160" height="45"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="45" id="xSW-Qw-A6r"/>
                                 </constraints>
                                 <fontDescription key="fontDescription" type="system" pointSize="18"/>
                                 <state key="normal" title="Control"/>
                                 <connections>
-                                    <action selector="onSelectControl:" destination="UJ4-id-d2U" eventType="touchUpInside" id="OHo-yp-sev"/>
+                                    <action selector="onUpdateType:" destination="UJ4-id-d2U" eventType="touchUpInside" id="2TZ-49-hfC"/>
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="vuK-TA-H0D">
-                                <rect key="frame" x="0.0" y="195.5" width="150" height="45"/>
+                                <rect key="frame" x="0.0" y="195.5" width="160" height="45"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="18"/>
                                 <state key="normal" title="Ignore"/>
                                 <connections>
-                                    <action selector="onSelectIgnore:" destination="UJ4-id-d2U" eventType="touchUpInside" id="0lQ-cZ-91Q"/>
+                                    <action selector="onUpdateType:" destination="UJ4-id-d2U" eventType="touchUpInside" id="KP6-Hh-ITN"/>
                                 </connections>
                             </button>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Type" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="XpF-ER-bKZ">
-                                <rect key="frame" x="60" y="83" width="30" height="14.5"/>
+                                <rect key="frame" x="65" y="83" width="30" height="14.5"/>
                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="12"/>
                                 <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="2ci-PB-PXB">
-                                <rect key="frame" x="0.0" y="150.5" width="150" height="45"/>
+                                <rect key="frame" x="0.0" y="150.5" width="160" height="45"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="18"/>
                                 <state key="normal" title="Monitor"/>
                                 <connections>
-                                    <action selector="onSelectMonitor:" destination="UJ4-id-d2U" eventType="touchUpInside" id="dZI-rd-4jq"/>
+                                    <action selector="onUpdateType:" destination="UJ4-id-d2U" eventType="touchUpInside" id="ayN-zT-Y0l"/>
                                 </connections>
                             </button>
+                            <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Nmq-8U-fah">
+                                <rect key="frame" x="23.5" y="271.5" width="51" height="31"/>
+                                <connections>
+                                    <action selector="onUpdateValue" destination="UJ4-id-d2U" eventType="valueChanged" id="aiH-KE-b6N"/>
+                                </connections>
+                            </switch>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Default Value" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="CXO-1x-Z4T">
+                                <rect key="frame" x="39.5" y="248.5" width="81" height="15"/>
+                                <fontDescription key="fontDescription" type="boldSystem" pointSize="12"/>
+                                <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="ON/OFF" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="joV-H0-vnC">
+                                <rect key="frame" x="81" y="277" width="62" height="21"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <constraints>
+                            <constraint firstItem="Nmq-8U-fah" firstAttribute="centerX" secondItem="dTS-dG-j8M" secondAttribute="centerX" constant="-32" id="1Xt-Rj-pOA"/>
                             <constraint firstItem="2ci-PB-PXB" firstAttribute="top" secondItem="ZcF-Ib-Hs1" secondAttribute="bottom" id="5o8-h4-4CF"/>
                             <constraint firstItem="vuK-TA-H0D" firstAttribute="height" secondItem="ZcF-Ib-Hs1" secondAttribute="height" id="7RB-45-ACT"/>
                             <constraint firstItem="vuK-TA-H0D" firstAttribute="width" secondItem="dTS-dG-j8M" secondAttribute="width" id="7sp-I4-R7o"/>
                             <constraint firstItem="2ci-PB-PXB" firstAttribute="centerX" secondItem="dTS-dG-j8M" secondAttribute="centerX" id="DoB-dF-6vX"/>
                             <constraint firstAttribute="trailingMargin" secondItem="n2g-c0-oaU" secondAttribute="trailing" id="Er5-M7-me1"/>
+                            <constraint firstItem="joV-H0-vnC" firstAttribute="centerY" secondItem="Nmq-8U-fah" secondAttribute="centerY" id="K1F-nH-k5n"/>
                             <constraint firstItem="n2g-c0-oaU" firstAttribute="leading" secondItem="dTS-dG-j8M" secondAttribute="leadingMargin" id="KV4-Bl-xWH"/>
                             <constraint firstItem="ZcF-Ib-Hs1" firstAttribute="centerX" secondItem="dTS-dG-j8M" secondAttribute="centerX" id="L6u-Mx-dtA"/>
                             <constraint firstItem="vuK-TA-H0D" firstAttribute="top" secondItem="2ci-PB-PXB" secondAttribute="bottom" id="LFn-rQ-jyN"/>
+                            <constraint firstItem="joV-H0-vnC" firstAttribute="centerX" secondItem="dTS-dG-j8M" secondAttribute="centerX" constant="32" id="MNd-YM-gyo"/>
                             <constraint firstItem="2ci-PB-PXB" firstAttribute="height" secondItem="ZcF-Ib-Hs1" secondAttribute="height" id="MzA-Pp-cxY"/>
                             <constraint firstItem="XpF-ER-bKZ" firstAttribute="centerX" secondItem="dTS-dG-j8M" secondAttribute="centerX" id="N9g-VK-JFI"/>
                             <constraint firstItem="XpF-ER-bKZ" firstAttribute="top" secondItem="n2g-c0-oaU" secondAttribute="bottom" constant="8" id="OMz-1u-DPg"/>
                             <constraint firstItem="n2g-c0-oaU" firstAttribute="centerX" secondItem="dTS-dG-j8M" secondAttribute="centerX" id="S6G-NB-Dav"/>
+                            <constraint firstItem="CXO-1x-Z4T" firstAttribute="top" secondItem="vuK-TA-H0D" secondAttribute="bottom" constant="8" id="StR-Qs-hGd"/>
                             <constraint firstItem="ZcF-Ib-Hs1" firstAttribute="top" secondItem="XpF-ER-bKZ" secondAttribute="bottom" constant="8" id="cH1-jC-pQ2"/>
                             <constraint firstItem="vuK-TA-H0D" firstAttribute="centerX" secondItem="dTS-dG-j8M" secondAttribute="centerX" id="djr-ZE-Oh0"/>
                             <constraint firstItem="vbH-px-ScG" firstAttribute="centerX" secondItem="dTS-dG-j8M" secondAttribute="centerX" id="hOn-LN-lR1"/>
                             <constraint firstItem="ZcF-Ib-Hs1" firstAttribute="width" secondItem="dTS-dG-j8M" secondAttribute="width" id="kza-QF-Dh1"/>
+                            <constraint firstItem="CXO-1x-Z4T" firstAttribute="centerX" secondItem="dTS-dG-j8M" secondAttribute="centerX" id="m82-dh-MVG"/>
                             <constraint firstItem="n2g-c0-oaU" firstAttribute="top" secondItem="vbH-px-ScG" secondAttribute="bottom" constant="8" id="oAw-yq-bpw"/>
                             <constraint firstItem="2ci-PB-PXB" firstAttribute="width" secondItem="dTS-dG-j8M" secondAttribute="width" id="oug-92-3LO"/>
+                            <constraint firstItem="Nmq-8U-fah" firstAttribute="top" secondItem="CXO-1x-Z4T" secondAttribute="bottom" constant="8" id="rOE-ZD-lo6"/>
                             <constraint firstItem="vbH-px-ScG" firstAttribute="top" secondItem="mTM-EQ-oSD" secondAttribute="bottom" constant="16" id="ynC-qB-PZS"/>
                         </constraints>
                     </view>
@@ -98,23 +122,25 @@
                     <nil key="simulatedTopBarMetrics"/>
                     <nil key="simulatedBottomBarMetrics"/>
                     <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
-                    <size key="freeformSize" width="150" height="250"/>
+                    <size key="freeformSize" width="160" height="320"/>
                     <connections>
                         <outlet property="controlButton" destination="ZcF-Ib-Hs1" id="hK6-6T-bKI"/>
                         <outlet property="header" destination="vbH-px-ScG" id="iok-kU-oIs"/>
                         <outlet property="ignoreButton" destination="vuK-TA-H0D" id="nhX-zJ-uVx"/>
                         <outlet property="monitorButton" destination="2ci-PB-PXB" id="hXu-T5-l76"/>
                         <outlet property="nameBox" destination="n2g-c0-oaU" id="JYU-OV-Fh8"/>
+                        <outlet property="onOffLabel" destination="joV-H0-vnC" id="bkZ-Sb-gdA"/>
+                        <outlet property="onOffSwitch" destination="Nmq-8U-fah" id="eH8-87-qio"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="wsq-57-MHM" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-1078" y="503"/>
+            <point key="canvasLocation" x="-1078.4000000000001" y="502.84857571214394"/>
         </scene>
-        <!--Pinout Diagram-->
+        <!--Raspberry Pi 3-->
         <scene sceneID="rOj-KT-kHv">
             <objects>
-                <viewController storyboardIdentifier="PINOUT_DIAGRAM" title="Pinout Diagram" modalTransitionStyle="crossDissolve" modalPresentationStyle="overCurrentContext" useStoryboardIdentifierAsRestorationIdentifier="YES" id="9SN-ti-ccR" customClass="PopoverViewController" customModule="PiPremote" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="PINOUT_DIAGRAM" title="Raspberry Pi 3" modalTransitionStyle="crossDissolve" modalPresentationStyle="overCurrentContext" useStoryboardIdentifierAsRestorationIdentifier="YES" id="9SN-ti-ccR" customClass="PiDiagramViewController" customModule="PiPremote" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="U13-t9-vsJ"/>
                         <viewControllerLayoutGuide type="bottom" id="zGD-E5-2ET"/>
@@ -123,15 +149,6 @@
                         <rect key="frame" x="0.0" y="0.0" width="250" height="400"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Pin Diagram" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Kgn-Nx-nO4">
-                                <rect key="frame" x="16" y="8" width="218" height="28.5"/>
-                                <fontDescription key="fontDescription" type="boldSystem" pointSize="18"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="249" verticalCompressionResistancePriority="749" translatesAutoresizingMaskIntoConstraints="NO" id="VWl-Vx-pLd">
-                                <rect key="frame" x="16" y="44.5" width="218" height="311"/>
-                            </imageView>
                             <toolbar opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="f4Y-17-IDr">
                                 <rect key="frame" x="0.0" y="356" width="250" height="44"/>
                                 <items>
@@ -144,22 +161,28 @@
                                     <barButtonItem style="plain" systemItem="flexibleSpace" id="oAf-Nc-KaG"/>
                                 </items>
                             </toolbar>
+                            <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="749" translatesAutoresizingMaskIntoConstraints="NO" id="VWl-Vx-pLd">
+                                <rect key="frame" x="16" y="29" width="218" height="319"/>
+                            </imageView>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Type of Pi" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="FHc-CY-ebf">
+                                <rect key="frame" x="16" y="4" width="218" height="21"/>
+                                <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <constraints>
                             <constraint firstAttribute="trailing" secondItem="f4Y-17-IDr" secondAttribute="trailing" id="1un-Mn-Tdy"/>
-                            <constraint firstItem="Kgn-Nx-nO4" firstAttribute="top" secondItem="U13-t9-vsJ" secondAttribute="bottom" constant="8" id="Cvu-RR-fa1"/>
                             <constraint firstItem="f4Y-17-IDr" firstAttribute="leading" secondItem="v5X-oQ-tEa" secondAttribute="leading" id="EY7-NQ-kF2"/>
-                            <constraint firstItem="VWl-Vx-pLd" firstAttribute="top" secondItem="Kgn-Nx-nO4" secondAttribute="bottom" priority="750" constant="8" id="Kr5-YG-2h7"/>
-                            <constraint firstItem="Kgn-Nx-nO4" firstAttribute="leading" secondItem="v5X-oQ-tEa" secondAttribute="leadingMargin" id="NH9-Ad-wNl"/>
-                            <constraint firstItem="VWl-Vx-pLd" firstAttribute="centerX" secondItem="v5X-oQ-tEa" secondAttribute="centerX" id="OGR-xO-ESr"/>
-                            <constraint firstItem="VWl-Vx-pLd" firstAttribute="width" secondItem="v5X-oQ-tEa" secondAttribute="height" multiplier="1:2" priority="750" id="ZdT-xq-AXt"/>
+                            <constraint firstItem="FHc-CY-ebf" firstAttribute="width" secondItem="VWl-Vx-pLd" secondAttribute="width" id="LMJ-8X-0kz"/>
+                            <constraint firstItem="VWl-Vx-pLd" firstAttribute="top" secondItem="FHc-CY-ebf" secondAttribute="bottom" constant="4" id="Qud-46-GKG"/>
+                            <constraint firstAttribute="trailingMargin" secondItem="VWl-Vx-pLd" secondAttribute="trailing" id="SL4-N3-jeF"/>
                             <constraint firstAttribute="bottom" secondItem="f4Y-17-IDr" secondAttribute="bottom" id="cTy-Zf-Glb"/>
-                            <constraint firstItem="Kgn-Nx-nO4" firstAttribute="trailing" secondItem="v5X-oQ-tEa" secondAttribute="trailingMargin" id="f5c-wL-5ZT"/>
-                            <constraint firstItem="f4Y-17-IDr" firstAttribute="top" secondItem="VWl-Vx-pLd" secondAttribute="bottom" id="ruI-Nx-XaN"/>
-                            <constraint firstItem="VWl-Vx-pLd" firstAttribute="centerY" secondItem="v5X-oQ-tEa" secondAttribute="centerY" id="s5C-ix-JMm"/>
-                            <constraint firstItem="VWl-Vx-pLd" firstAttribute="width" secondItem="Kgn-Nx-nO4" secondAttribute="width" id="yEm-PR-BGT"/>
-                            <constraint firstAttribute="trailing" secondItem="f4Y-17-IDr" secondAttribute="trailing" id="yhG-ay-Vah"/>
+                            <constraint firstItem="VWl-Vx-pLd" firstAttribute="leading" secondItem="v5X-oQ-tEa" secondAttribute="leadingMargin" id="d0Y-PG-90G"/>
+                            <constraint firstItem="FHc-CY-ebf" firstAttribute="top" secondItem="U13-t9-vsJ" secondAttribute="bottom" constant="4" id="iSN-0q-KEl"/>
+                            <constraint firstItem="FHc-CY-ebf" firstAttribute="centerX" secondItem="v5X-oQ-tEa" secondAttribute="centerX" id="kJu-I1-ukB"/>
+                            <constraint firstItem="f4Y-17-IDr" firstAttribute="top" secondItem="VWl-Vx-pLd" secondAttribute="bottom" constant="8" id="maK-WW-xfC"/>
                         </constraints>
                     </view>
                     <nil key="simulatedStatusBarMetrics"/>
@@ -167,10 +190,14 @@
                     <nil key="simulatedBottomBarMetrics"/>
                     <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
                     <size key="freeformSize" width="250" height="400"/>
+                    <connections>
+                        <outlet property="header" destination="FHc-CY-ebf" id="u18-rX-lRe"/>
+                        <outlet property="imageView" destination="VWl-Vx-pLd" id="zfw-iM-tBp"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="rOC-kz-qPx" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-150" y="571"/>
+            <point key="canvasLocation" x="-150.40000000000001" y="570.31484257871068"/>
         </scene>
         <!--Apply Layout-->
         <scene sceneID="OVa-W2-SNh">
@@ -445,11 +472,11 @@
                                 <rect key="frame" x="0.0" y="64" width="375" height="736"/>
                                 <subviews>
                                     <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" verticalCompressionResistancePriority="740" translatesAutoresizingMaskIntoConstraints="NO" id="45D-UB-cKK" customClass="PinSetupScrollView" customModule="PiPremote" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="0.0" width="375" height="406"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="375" height="356"/>
                                         <gestureRecognizers/>
                                     </scrollView>
                                     <toolbar opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="k7H-aB-lL9">
-                                        <rect key="frame" x="0.0" y="406" width="375" height="40"/>
+                                        <rect key="frame" x="0.0" y="356" width="375" height="40"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="40" id="UdJ-Bj-f0z"/>
                                         </constraints>
@@ -491,7 +518,7 @@
                                         </items>
                                     </toolbar>
                                     <button opaque="NO" contentMode="scaleToFill" verticalCompressionResistancePriority="760" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ION-D7-3bo">
-                                        <rect key="frame" x="0.0" y="446" width="375" height="40"/>
+                                        <rect key="frame" x="0.0" y="396" width="375" height="40"/>
                                         <color key="backgroundColor" red="0.97019999999999995" green="0.97019999999999995" blue="0.98999999999999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="40" id="bnR-8v-cpr"/>
@@ -505,7 +532,7 @@
                                         </connections>
                                     </button>
                                     <view contentMode="scaleToFill" verticalCompressionResistancePriority="730" translatesAutoresizingMaskIntoConstraints="NO" id="BBN-9a-2z8">
-                                        <rect key="frame" x="0.0" y="486" width="375" height="250"/>
+                                        <rect key="frame" x="0.0" y="436" width="375" height="300"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="When device shuts down unexpectedly:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2ZR-gG-vVD">
                                                 <rect key="frame" x="17" y="38" width="283.5" height="18"/>
@@ -570,10 +597,23 @@
                                                 <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Port #" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gPm-hQ-BWx">
+                                                <rect key="frame" x="17" y="228" width="82" height="19.5"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="16"/>
+                                                <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="8000" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="GyG-oP-W4m">
+                                                <rect key="frame" x="116" y="223" width="120" height="30"/>
+                                                <nil key="textColor"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                <textInputTraits key="textInputTraits"/>
+                                            </textField>
                                         </subviews>
                                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                         <gestureRecognizers/>
                                         <constraints>
+                                            <constraint firstItem="GyG-oP-W4m" firstAttribute="leading" secondItem="WPR-cb-9HB" secondAttribute="leading" id="2FD-5m-uVQ"/>
                                             <constraint firstItem="Njz-5V-hLT" firstAttribute="top" secondItem="BBN-9a-2z8" secondAttribute="top" constant="4" id="3dm-fl-nnm"/>
                                             <constraint firstItem="d6a-YE-Ztx" firstAttribute="centerY" secondItem="WPR-cb-9HB" secondAttribute="centerY" id="4v8-8A-myO"/>
                                             <constraint firstItem="WPR-cb-9HB" firstAttribute="trailing" secondItem="jmr-ZV-soy" secondAttribute="trailing" id="5TQ-Sc-P7u"/>
@@ -586,23 +626,28 @@
                                             <constraint firstItem="d6a-YE-Ztx" firstAttribute="top" secondItem="3aJ-fD-Ths" secondAttribute="bottom" constant="16" id="G14-Kp-SNa"/>
                                             <constraint firstItem="2ZR-gG-vVD" firstAttribute="leading" secondItem="3aJ-fD-Ths" secondAttribute="leading" id="GE8-P8-e7H"/>
                                             <constraint firstItem="2ZR-gG-vVD" firstAttribute="top" secondItem="Njz-5V-hLT" secondAttribute="bottom" constant="16" id="GUh-qM-nw9"/>
+                                            <constraint firstItem="gPm-hQ-BWx" firstAttribute="centerY" secondItem="GyG-oP-W4m" secondAttribute="centerY" id="Itt-iV-Vwv"/>
                                             <constraint firstItem="jmr-ZV-soy" firstAttribute="top" secondItem="WPR-cb-9HB" secondAttribute="bottom" constant="8" symbolic="YES" id="JGR-EG-ORD"/>
                                             <constraint firstItem="jmr-ZV-soy" firstAttribute="height" secondItem="WPR-cb-9HB" secondAttribute="height" id="NIO-FL-lTx"/>
-                                            <constraint firstAttribute="height" constant="250" id="QHU-Rg-dOp"/>
+                                            <constraint firstItem="gPm-hQ-BWx" firstAttribute="top" secondItem="Ytg-Qq-aCI" secondAttribute="bottom" constant="14" id="Py1-PH-Zwi"/>
+                                            <constraint firstAttribute="height" constant="300" id="QHU-Rg-dOp"/>
                                             <constraint firstItem="Sea-at-esL" firstAttribute="leading" secondItem="2ZR-gG-vVD" secondAttribute="leading" id="RPL-mR-f9S"/>
                                             <constraint firstItem="jmr-ZV-soy" firstAttribute="width" secondItem="WPR-cb-9HB" secondAttribute="width" id="V5I-cL-8Dg"/>
                                             <constraint firstItem="3aJ-fD-Ths" firstAttribute="top" secondItem="WBH-e4-gfD" secondAttribute="bottom" constant="24" id="V5u-Kk-b6j"/>
                                             <constraint firstItem="d6a-YE-Ztx" firstAttribute="leading" secondItem="BBN-9a-2z8" secondAttribute="leading" constant="17" id="XlA-vR-fec"/>
                                             <constraint firstItem="d6a-YE-Ztx" firstAttribute="leading" secondItem="3aJ-fD-Ths" secondAttribute="leading" id="ZLF-z4-NR7"/>
+                                            <constraint firstItem="gPm-hQ-BWx" firstAttribute="leading" secondItem="3aJ-fD-Ths" secondAttribute="leading" id="bAX-dx-bI9"/>
                                             <constraint firstItem="WPR-cb-9HB" firstAttribute="leading" secondItem="d6a-YE-Ztx" secondAttribute="trailing" constant="17" id="dUV-Xa-IGh"/>
                                             <constraint firstItem="Ytg-Qq-aCI" firstAttribute="height" secondItem="d6a-YE-Ztx" secondAttribute="height" id="hur-DB-nJP"/>
                                             <constraint firstItem="WPR-cb-9HB" firstAttribute="leading" secondItem="jmr-ZV-soy" secondAttribute="leading" id="i7e-bA-jFC"/>
                                             <constraint firstItem="t46-Rn-4Fd" firstAttribute="centerY" secondItem="Njz-5V-hLT" secondAttribute="centerY" id="iTM-tq-o1L"/>
                                             <constraint firstItem="WPR-cb-9HB" firstAttribute="baseline" secondItem="d6a-YE-Ztx" secondAttribute="firstBaseline" id="igq-mg-AG1"/>
+                                            <constraint firstItem="gPm-hQ-BWx" firstAttribute="width" secondItem="Ytg-Qq-aCI" secondAttribute="width" id="jND-yJ-ISx"/>
                                             <constraint firstItem="Ytg-Qq-aCI" firstAttribute="width" secondItem="d6a-YE-Ztx" secondAttribute="width" id="k1m-lf-1gR"/>
                                             <constraint firstItem="t46-Rn-4Fd" firstAttribute="trailing" secondItem="WBH-e4-gfD" secondAttribute="trailing" id="lj3-KR-n4X"/>
                                             <constraint firstItem="t46-Rn-4Fd" firstAttribute="leading" secondItem="Njz-5V-hLT" secondAttribute="trailing" constant="16" id="pin-fp-DDf"/>
                                             <constraint firstItem="Ytg-Qq-aCI" firstAttribute="centerY" secondItem="jmr-ZV-soy" secondAttribute="centerY" id="sXB-C8-ueG"/>
+                                            <constraint firstItem="GyG-oP-W4m" firstAttribute="width" secondItem="jmr-ZV-soy" secondAttribute="width" multiplier="0.5" id="t7m-MD-VNT"/>
                                             <constraint firstItem="d6a-YE-Ztx" firstAttribute="leading" secondItem="Ytg-Qq-aCI" secondAttribute="leading" id="yEl-Hy-yP3"/>
                                             <constraint firstItem="d6a-YE-Ztx" firstAttribute="trailing" secondItem="Ytg-Qq-aCI" secondAttribute="trailing" id="zIL-AG-e1B"/>
                                         </constraints>

--- a/PiRemote/PiRemote.xcodeproj/project.pbxproj
+++ b/PiRemote/PiRemote.xcodeproj/project.pbxproj
@@ -35,6 +35,7 @@
 		C0C791311E62217200D94A13 /* DeviceTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0C791301E62217200D94A13 /* DeviceTableViewCell.swift */; };
 		C0E77BF11E96D27D009A36CA /* ApplyLayoutViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0E77BF01E96D27D009A36CA /* ApplyLayoutViewController.swift */; };
 		C0ED02901E9ABA2B00DEFDC8 /* EditPinViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0ED028F1E9ABA2B00DEFDC8 /* EditPinViewController.swift */; };
+		C0F34AEE1E9D66420015958F /* PiDiagramViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0F34AED1E9D66420015958F /* PiDiagramViewController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -81,6 +82,7 @@
 		C0C791301E62217200D94A13 /* DeviceTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeviceTableViewCell.swift; sourceTree = "<group>"; };
 		C0E77BF01E96D27D009A36CA /* ApplyLayoutViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ApplyLayoutViewController.swift; sourceTree = "<group>"; };
 		C0ED028F1E9ABA2B00DEFDC8 /* EditPinViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EditPinViewController.swift; sourceTree = "<group>"; };
+		C0F34AED1E9D66420015958F /* PiDiagramViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PiDiagramViewController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -136,6 +138,7 @@
 				C08665A41E9137EA002A106D /* PopoverViewController.swift */,
 				C0E77BF01E96D27D009A36CA /* ApplyLayoutViewController.swift */,
 				C0ED028F1E9ABA2B00DEFDC8 /* EditPinViewController.swift */,
+				C0F34AED1E9D66420015958F /* PiDiagramViewController.swift */,
 			);
 			name = ViewController;
 			sourceTree = "<group>";
@@ -340,6 +343,7 @@
 				5AD0606E1CAD8E9800BD6930 /* AppDelegate.swift in Sources */,
 				C0C791311E62217200D94A13 /* DeviceTableViewCell.swift in Sources */,
 				24C6D9511E44DC5000C3365D /* APIManager.swift in Sources */,
+				C0F34AEE1E9D66420015958F /* PiDiagramViewController.swift in Sources */,
 				5AD060901CAD9E7700BD6930 /* PinTableViewCell.swift in Sources */,
 				241C59CE1E81A94100BBF2B2 /* SysConstants.swift in Sources */,
 				C0E77BF11E96D27D009A36CA /* ApplyLayoutViewController.swift in Sources */,

--- a/PiRemote/PiRemote.xcodeproj/project.pbxproj
+++ b/PiRemote/PiRemote.xcodeproj/project.pbxproj
@@ -19,7 +19,6 @@
 		5AD060781CAD8E9800BD6930 /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 5AD060761CAD8E9800BD6930 /* LaunchScreen.xib */; };
 		5AD060841CAD8E9800BD6930 /* Attempt2Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AD060831CAD8E9800BD6930 /* Attempt2Tests.swift */; };
 		5AD0608E1CAD96B100BD6930 /* Pin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AD0608D1CAD96B100BD6930 /* Pin.swift */; };
-		5AD060901CAD9E7700BD6930 /* PinTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AD0608F1CAD9E7700BD6930 /* PinTableViewCell.swift */; };
 		C001CE231E8CB8A200DAA710 /* PinLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = C001CE221E8CB8A200DAA710 /* PinLayout.swift */; };
 		C02614181E86EC71002B725F /* WebLoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C02614171E86EC71002B725F /* WebLoginViewController.swift */; };
 		C0287E601E90B367009D4578 /* DeviceSetup.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C0287E5F1E90B367009D4578 /* DeviceSetup.storyboard */; };
@@ -27,6 +26,7 @@
 		C0587EE01E9AD413000F6FAC /* DeviceSetupViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0587EDF1E9AD413000F6FAC /* DeviceSetupViewController.swift */; };
 		C08665A51E9137EA002A106D /* PopoverViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C08665A41E9137EA002A106D /* PopoverViewController.swift */; };
 		C0A3C3851E9A607B007D953B /* PinSetupScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0A3C3841E9A607B007D953B /* PinSetupScrollView.swift */; };
+		C0B3ECD51E9EF4D60005488A /* PinTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0B3ECD41E9EF4D60005488A /* PinTableViewCell.swift */; };
 		C0C1C1721E6CC90F005DE3B2 /* RemoteAPIManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0C1C1711E6CC90F005DE3B2 /* RemoteAPIManager.swift */; };
 		C0C1C1751E6CC923005DE3B2 /* RemoteDevice.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0C1C1731E6CC923005DE3B2 /* RemoteDevice.swift */; };
 		C0C1C1761E6CC923005DE3B2 /* RemoteDeviceManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0C1C1741E6CC923005DE3B2 /* RemoteDeviceManager.swift */; };
@@ -66,7 +66,6 @@
 		5AD060821CAD8E9800BD6930 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		5AD060831CAD8E9800BD6930 /* Attempt2Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = Attempt2Tests.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		5AD0608D1CAD96B100BD6930 /* Pin.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = Pin.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
-		5AD0608F1CAD9E7700BD6930 /* PinTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PinTableViewCell.swift; sourceTree = "<group>"; };
 		C001CE221E8CB8A200DAA710 /* PinLayout.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PinLayout.swift; sourceTree = "<group>"; };
 		C02614171E86EC71002B725F /* WebLoginViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WebLoginViewController.swift; sourceTree = "<group>"; };
 		C0287E5F1E90B367009D4578 /* DeviceSetup.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = DeviceSetup.storyboard; path = ../DeviceSetup.storyboard; sourceTree = "<group>"; };
@@ -74,6 +73,7 @@
 		C0587EDF1E9AD413000F6FAC /* DeviceSetupViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeviceSetupViewController.swift; sourceTree = "<group>"; };
 		C08665A41E9137EA002A106D /* PopoverViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PopoverViewController.swift; sourceTree = "<group>"; };
 		C0A3C3841E9A607B007D953B /* PinSetupScrollView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PinSetupScrollView.swift; sourceTree = "<group>"; };
+		C0B3ECD41E9EF4D60005488A /* PinTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PinTableViewCell.swift; sourceTree = "<group>"; };
 		C0C1C1711E6CC90F005DE3B2 /* RemoteAPIManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RemoteAPIManager.swift; sourceTree = "<group>"; };
 		C0C1C1731E6CC923005DE3B2 /* RemoteDevice.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RemoteDevice.swift; sourceTree = "<group>"; };
 		C0C1C1741E6CC923005DE3B2 /* RemoteDeviceManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RemoteDeviceManager.swift; sourceTree = "<group>"; };
@@ -120,7 +120,7 @@
 		24C6D94A1E44D09B00C3365D /* View */ = {
 			isa = PBXGroup;
 			children = (
-				5AD0608F1CAD9E7700BD6930 /* PinTableViewCell.swift */,
+				C0B3ECD41E9EF4D60005488A /* PinTableViewCell.swift */,
 				C0C791301E62217200D94A13 /* DeviceTableViewCell.swift */,
 				C0A3C3841E9A607B007D953B /* PinSetupScrollView.swift */,
 			);
@@ -333,6 +333,7 @@
 				C0C1C1781E6CFBF3005DE3B2 /* WebAPIManager.swift in Sources */,
 				C0C7912F1E6215AC00D94A13 /* DevicesTableViewController.swift in Sources */,
 				C0ED02901E9ABA2B00DEFDC8 /* EditPinViewController.swift in Sources */,
+				C0B3ECD51E9EF4D60005488A /* PinTableViewCell.swift in Sources */,
 				5AD0608E1CAD96B100BD6930 /* Pin.swift in Sources */,
 				2484B3CB1E79E708000770E5 /* AppEngineManager.swift in Sources */,
 				C02614181E86EC71002B725F /* WebLoginViewController.swift in Sources */,
@@ -344,7 +345,6 @@
 				C0C791311E62217200D94A13 /* DeviceTableViewCell.swift in Sources */,
 				24C6D9511E44DC5000C3365D /* APIManager.swift in Sources */,
 				C0F34AEE1E9D66420015958F /* PiDiagramViewController.swift in Sources */,
-				5AD060901CAD9E7700BD6930 /* PinTableViewCell.swift in Sources */,
 				241C59CE1E81A94100BBF2B2 /* SysConstants.swift in Sources */,
 				C0E77BF11E96D27D009A36CA /* ApplyLayoutViewController.swift in Sources */,
 				2447F0891E5E39E800EE1B69 /* MainUser.swift in Sources */,

--- a/PiRemote/PiRemote/Base.lproj/Main.storyboard
+++ b/PiRemote/PiRemote/Base.lproj/Main.storyboard
@@ -93,7 +93,7 @@
                                 </state>
                                 <connections>
                                     <action selector="handleTapLogin" destination="Quz-7m-Y6X" eventType="touchDown" id="V8a-z2-tje"/>
-                                    <segue destination="TKw-YT-88J" kind="show" identifier="SHOW_DEVICES_TABLE" id="crl-WW-GCD"/>
+                                    <segue destination="TKw-YT-88J" kind="show" identifier="SHOW_DEVICES" id="crl-WW-GCD"/>
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="vsU-qt-h8N">
@@ -183,6 +183,7 @@
                         </connections>
                     </tableView>
                     <navigationItem key="navigationItem" title="My Devices" id="vnp-jt-51a"/>
+                    <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" prompted="NO"/>
                     <connections>
                         <outlet property="devicesTableView" destination="5zE-OH-Bjc" id="2wn-MB-Gwg"/>
                         <segue destination="6JH-BG-EKY" kind="popoverPresentation" identifier="SHOW_WEBIOPI_LOGIN" popoverAnchorView="5zE-OH-Bjc" id="6OX-KP-xtE">
@@ -438,6 +439,6 @@
         <image name="cross" width="24" height="24"/>
     </resources>
     <inferredMetricsTieBreakers>
-        <segue reference="otq-FB-Afg"/>
+        <segue reference="1Lx-Gl-rNf"/>
     </inferredMetricsTieBreakers>
 </document>

--- a/PiRemote/PiRemote/Base.lproj/Main.storyboard
+++ b/PiRemote/PiRemote/Base.lproj/Main.storyboard
@@ -4,8 +4,9 @@
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
-        <deployment identifier="iOS"/>
+        <deployment version="2304" identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11757"/>
+        <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -17,7 +18,7 @@
                 </viewControllerPlaceholder>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="b75-uM-4Ki" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="4858" y="-396"/>
+            <point key="canvasLocation" x="4877" y="-510"/>
         </scene>
         <!--App Nav-->
         <scene sceneID="KFk-LC-bCc">
@@ -38,7 +39,7 @@
                 </navigationController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="ni1-vs-obJ" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="2391" y="-1016"/>
+            <point key="canvasLocation" x="2578" y="-1016"/>
         </scene>
         <!--Remote Login-->
         <scene sceneID="mgV-s7-h5q">
@@ -96,14 +97,6 @@
                                     <segue destination="TKw-YT-88J" kind="show" identifier="SHOW_DEVICES" id="crl-WW-GCD"/>
                                 </connections>
                             </button>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="vsU-qt-h8N">
-                                <rect key="frame" x="164" y="570" width="46" height="30"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <state key="normal" title="Button"/>
-                                <connections>
-                                    <segue destination="Bie-XA-VK0" kind="show" id="otq-FB-Afg"/>
-                                </connections>
-                            </button>
                         </subviews>
                         <color key="backgroundColor" red="0.52387019600082985" green="0.6388505154697397" blue="0.72488547120418856" alpha="1" colorSpace="calibratedRGB"/>
                     </view>
@@ -129,20 +122,12 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                        <button key="tableFooterView" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" id="hK9-Yi-AZJ">
-                            <rect key="frame" x="0.0" y="74" width="375" height="44"/>
-                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                            <state key="normal" title="Add Device"/>
-                            <connections>
-                                <segue destination="Bie-XA-VK0" kind="show" id="B5N-N2-UJq"/>
-                            </connections>
-                        </button>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="DEVICE CELL" rowHeight="46" id="BUP-M4-lme" customClass="DeviceTableViewCell" customModule="PiPremote">
                                 <rect key="frame" x="0.0" y="28" width="375" height="46"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="BUP-M4-lme" id="hna-XB-n2r">
-                                    <rect key="frame" x="0.0" y="0.0" width="375" height="45"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="375" height="46"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Device Name" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ehd-Zf-eut">
@@ -166,10 +151,6 @@
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
-                                        <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" image="contrast" translatesAutoresizingMaskIntoConstraints="NO" id="crY-0F-25G">
-                                            <rect key="frame" x="343" y="10" width="24" height="24"/>
-                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                        </imageView>
                                     </subviews>
                                 </tableViewCellContentView>
                                 <connections>
@@ -194,7 +175,7 @@
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="jIN-cU-bQA" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="4321" y="-1016"/>
+            <point key="canvasLocation" x="4124" y="-1016"/>
         </scene>
         <!--WebIOPi Login-->
         <scene sceneID="CmD-TG-jfp">
@@ -326,7 +307,7 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="3sX-Bx-KWi" userLabel="First Responder" sceneMemberID="firstResponder"/>
                 <exit id="IJq-R4-iqG" userLabel="Exit" sceneMemberID="exit"/>
             </objects>
-            <point key="canvasLocation" x="4277" y="-77"/>
+            <point key="canvasLocation" x="4123" y="-379"/>
         </scene>
         <!--Device Info-->
         <scene sceneID="cbM-Tn-fD1">
@@ -337,108 +318,318 @@
                         <viewControllerLayoutGuide type="bottom" id="XSW-mF-0NZ"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="Jsw-CW-cDy">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="850"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <tableView clipsSubviews="YES" contentMode="scaleToFill" fixedFrame="YES" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="53" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="kOI-yq-mVd" userLabel="Pin Table">
-                                <rect key="frame" x="0.0" y="101" width="375" height="566"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                                <prototypes>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="PIN CELL" rowHeight="53" id="UyT-gc-Bdv" userLabel="PIN CELL" customClass="PinTableViewCell" customModule="PiPremote" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="28" width="375" height="53"/>
-                                        <autoresizingMask key="autoresizingMask"/>
-                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="UyT-gc-Bdv" id="2fM-TE-gYv">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="52"/>
-                                            <autoresizingMask key="autoresizingMask"/>
-                                            <subviews>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Pin Name" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="nC2-kq-tph">
-                                                    <rect key="frame" x="8" y="8" width="158" height="34"/>
-                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                    <nil key="textColor"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Type" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zyn-wX-gJG">
-                                                    <rect key="frame" x="174" y="8" width="87" height="34"/>
-                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                    <nil key="textColor"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="#" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="i6t-6y-VNP">
-                                                    <rect key="frame" x="269" y="8" width="46" height="34"/>
-                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                    <nil key="textColor"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                                <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="74b-Dm-JWL">
-                                                    <rect key="frame" x="318" y="10" width="51" height="31"/>
-                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                                    <rect key="contentStretch" x="0.0" y="0.0" width="0.75" height="0.75"/>
-                                                    <connections>
-                                                        <action selector="onToggleSwitch:" destination="eAF-Vh-bmA" eventType="valueChanged" id="bdR-ef-A6A"/>
-                                                    </connections>
-                                                </switch>
-                                            </subviews>
-                                        </tableViewCellContentView>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="Xts-aI-bjy">
+                                <rect key="frame" x="16" y="64" width="343" height="786"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Device Name" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="srK-Hn-pQh">
+                                        <rect key="frame" x="0.0" y="0.0" width="343" height="30"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="30" id="4CE-um-Q2n"/>
+                                        </constraints>
+                                        <fontDescription key="fontDescription" type="system" weight="medium" pointSize="18"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="uWb-SA-fFO" userLabel="Immediate Info">
+                                        <rect key="frame" x="0.0" y="30" width="343" height="60"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Last Updated" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tYZ-9V-ncL">
+                                                <rect key="frame" x="187.5" y="8" width="108.5" height="17"/>
+                                                <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="14"/>
+                                                <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="3 minutes ago" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ooz-ko-dkM">
+                                                <rect key="frame" x="187.5" y="29" width="108.5" height="20.5"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Online" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="j7c-xf-yfD">
+                                                <rect key="frame" x="0.0" y="12.5" width="140" height="35"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="35" id="Yv4-tb-XeS"/>
+                                                    <constraint firstAttribute="width" constant="140" id="fQn-Bd-cUg"/>
+                                                </constraints>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                        </subviews>
+                                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                        <constraints>
+                                            <constraint firstItem="j7c-xf-yfD" firstAttribute="leading" secondItem="uWb-SA-fFO" secondAttribute="leading" id="1ld-hW-wgh"/>
+                                            <constraint firstAttribute="height" constant="60" id="7Mv-V0-ALy"/>
+                                            <constraint firstItem="Ooz-ko-dkM" firstAttribute="width" secondItem="tYZ-9V-ncL" secondAttribute="width" id="87R-tH-Vtv"/>
+                                            <constraint firstItem="Ooz-ko-dkM" firstAttribute="centerX" secondItem="tYZ-9V-ncL" secondAttribute="centerX" id="Ia2-Ft-rV6"/>
+                                            <constraint firstItem="Ooz-ko-dkM" firstAttribute="top" secondItem="tYZ-9V-ncL" secondAttribute="bottom" constant="4" id="Wia-Mk-iSc"/>
+                                            <constraint firstItem="j7c-xf-yfD" firstAttribute="centerY" secondItem="uWb-SA-fFO" secondAttribute="centerY" id="hem-sq-JOz"/>
+                                            <constraint firstItem="tYZ-9V-ncL" firstAttribute="centerX" secondItem="uWb-SA-fFO" secondAttribute="centerX" constant="70" id="k0h-Ri-Rmu"/>
+                                            <constraint firstItem="tYZ-9V-ncL" firstAttribute="top" secondItem="uWb-SA-fFO" secondAttribute="top" constant="8" id="mNB-Pi-MWC"/>
+                                        </constraints>
+                                    </view>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="yU9-mF-1h1" userLabel="Table Header">
+                                        <rect key="frame" x="0.0" y="90" width="343" height="30"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Pin Name" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="unU-og-dMK">
+                                                <rect key="frame" x="97" y="0.0" width="65.5" height="30"/>
+                                                <fontDescription key="fontDescription" type="boldSystem" pointSize="14"/>
+                                                <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Type" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="rzV-3W-L7f">
+                                                <rect key="frame" x="214.5" y="0.0" width="34.5" height="30"/>
+                                                <fontDescription key="fontDescription" type="boldSystem" pointSize="14"/>
+                                                <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Status" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="OPK-0i-feZ">
+                                                <rect key="frame" x="281.5" y="0.0" width="45.5" height="30"/>
+                                                <fontDescription key="fontDescription" type="boldSystem" pointSize="14"/>
+                                                <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                        </subviews>
+                                        <color key="backgroundColor" red="0.96078431372549022" green="0.96078431372549022" blue="0.98431372549019602" alpha="1" colorSpace="calibratedRGB"/>
+                                        <constraints>
+                                            <constraint firstItem="OPK-0i-feZ" firstAttribute="top" secondItem="yU9-mF-1h1" secondAttribute="top" id="0hu-9Y-Sc2"/>
+                                            <constraint firstItem="rzV-3W-L7f" firstAttribute="centerX" secondItem="yU9-mF-1h1" secondAttribute="centerX" constant="60" id="3vl-Mp-19C"/>
+                                            <constraint firstAttribute="trailing" secondItem="OPK-0i-feZ" secondAttribute="trailing" constant="16" id="F07-8w-j8U"/>
+                                            <constraint firstAttribute="bottom" secondItem="OPK-0i-feZ" secondAttribute="bottom" id="Jsg-dW-xL5"/>
+                                            <constraint firstItem="rzV-3W-L7f" firstAttribute="top" secondItem="yU9-mF-1h1" secondAttribute="top" id="PnW-ms-GOK"/>
+                                            <constraint firstItem="unU-og-dMK" firstAttribute="top" secondItem="yU9-mF-1h1" secondAttribute="top" id="bhh-7t-ACM"/>
+                                            <constraint firstAttribute="bottom" secondItem="unU-og-dMK" secondAttribute="bottom" id="eza-Vr-3Xd"/>
+                                            <constraint firstAttribute="bottom" secondItem="rzV-3W-L7f" secondAttribute="bottom" id="ww2-om-tKp"/>
+                                            <constraint firstItem="unU-og-dMK" firstAttribute="centerX" secondItem="yU9-mF-1h1" secondAttribute="centerX" constant="-42" id="x3i-jw-a90"/>
+                                        </constraints>
+                                    </view>
+                                    <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="cwg-eM-kyT">
+                                        <rect key="frame" x="0.0" y="120" width="343" height="286"/>
+                                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                        <prototypes>
+                                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="PIN CELL" rowHeight="80" id="uaq-A8-3E1" customClass="PinTableViewCell" customModule="PiPremote" customModuleProvider="target">
+                                                <rect key="frame" x="0.0" y="28" width="343" height="80"/>
+                                                <autoresizingMask key="autoresizingMask"/>
+                                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="uaq-A8-3E1" id="DJs-Ox-4qv">
+                                                    <rect key="frame" x="0.0" y="0.0" width="343" height="79"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <subviews>
+                                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="kx1-yi-eOo">
+                                                            <rect key="frame" x="8" y="9" width="60" height="60"/>
+                                                            <constraints>
+                                                                <constraint firstAttribute="height" constant="60" id="MfI-ih-t5r"/>
+                                                                <constraint firstAttribute="width" constant="60" id="oqU-gp-YUj"/>
+                                                            </constraints>
+                                                            <state key="normal" title="#"/>
+                                                        </button>
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Pin Name" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="nC2-kq-tph">
+                                                            <rect key="frame" x="76" y="29" width="104" height="21"/>
+                                                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                            <nil key="textColor"/>
+                                                            <nil key="highlightedColor"/>
+                                                        </label>
+                                                        <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="NsS-nV-gfg">
+                                                            <rect key="frame" x="276" y="24" width="51" height="31"/>
+                                                            <connections>
+                                                                <action selector="onToggleSwitch:" destination="uaq-A8-3E1" eventType="valueChanged" id="2m5-3X-vQY"/>
+                                                            </connections>
+                                                        </switch>
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Type" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zyn-wX-gJG">
+                                                            <rect key="frame" x="188" y="29" width="80" height="21"/>
+                                                            <constraints>
+                                                                <constraint firstAttribute="width" constant="80" id="4yE-e6-cvd"/>
+                                                            </constraints>
+                                                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                            <nil key="textColor"/>
+                                                            <nil key="highlightedColor"/>
+                                                        </label>
+                                                    </subviews>
+                                                    <constraints>
+                                                        <constraint firstItem="kx1-yi-eOo" firstAttribute="centerY" secondItem="DJs-Ox-4qv" secondAttribute="centerY" id="4cg-Vf-Tkd"/>
+                                                        <constraint firstItem="NsS-nV-gfg" firstAttribute="leading" secondItem="zyn-wX-gJG" secondAttribute="trailing" constant="8" id="8nt-eZ-u24"/>
+                                                        <constraint firstAttribute="trailingMargin" secondItem="NsS-nV-gfg" secondAttribute="trailing" constant="10" id="BjV-GM-s3T"/>
+                                                        <constraint firstItem="nC2-kq-tph" firstAttribute="centerY" secondItem="DJs-Ox-4qv" secondAttribute="centerY" id="FM6-vw-53T"/>
+                                                        <constraint firstItem="kx1-yi-eOo" firstAttribute="leading" secondItem="DJs-Ox-4qv" secondAttribute="leadingMargin" id="FZE-Ku-Bv7"/>
+                                                        <constraint firstItem="zyn-wX-gJG" firstAttribute="centerY" secondItem="DJs-Ox-4qv" secondAttribute="centerY" id="Sms-OC-rhH"/>
+                                                        <constraint firstItem="nC2-kq-tph" firstAttribute="leading" secondItem="kx1-yi-eOo" secondAttribute="trailing" constant="8" id="VKP-Bi-wcJ"/>
+                                                        <constraint firstItem="NsS-nV-gfg" firstAttribute="centerY" secondItem="DJs-Ox-4qv" secondAttribute="centerY" id="XV6-tL-Ucu"/>
+                                                        <constraint firstItem="nC2-kq-tph" firstAttribute="centerY" secondItem="DJs-Ox-4qv" secondAttribute="centerY" id="bBu-bu-5Pj"/>
+                                                        <constraint firstItem="zyn-wX-gJG" firstAttribute="leading" secondItem="nC2-kq-tph" secondAttribute="trailing" constant="8" id="t6x-HY-esN"/>
+                                                    </constraints>
+                                                </tableViewCellContentView>
+                                                <connections>
+                                                    <outlet property="pinNameLabel" destination="nC2-kq-tph" id="e0W-rY-pPx"/>
+                                                    <outlet property="pinView" destination="kx1-yi-eOo" id="RXH-3U-d2d"/>
+                                                    <outlet property="typeLabel" destination="zyn-wX-gJG" id="zHc-C5-74p"/>
+                                                    <outlet property="valueSwitch" destination="NsS-nV-gfg" id="6cX-Ah-hRj"/>
+                                                </connections>
+                                            </tableViewCell>
+                                        </prototypes>
                                         <connections>
-                                            <outlet property="nameLabel" destination="nC2-kq-tph" id="ToJ-n1-psB"/>
-                                            <outlet property="numberLabel" destination="i6t-6y-VNP" id="2uF-4X-7sh"/>
-                                            <outlet property="statusSwitch" destination="74b-Dm-JWL" id="o6H-g8-SZY"/>
-                                            <outlet property="typeLabel" destination="zyn-wX-gJG" id="haa-aO-V2s"/>
+                                            <outlet property="dataSource" destination="eAF-Vh-bmA" id="Cqz-ic-bOK"/>
                                         </connections>
-                                    </tableViewCell>
-                                </prototypes>
-                                <connections>
-                                    <outlet property="dataSource" destination="eAF-Vh-bmA" id="8nj-g6-OhR"/>
-                                </connections>
-                            </tableView>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Pin Name" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="unU-og-dMK">
-                                <rect key="frame" x="52" y="72" width="84" height="21"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <fontDescription key="fontDescription" type="boldSystem" pointSize="14"/>
-                                <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Type" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="y1J-N7-NSO">
-                                <rect key="frame" x="198" y="72" width="49" height="21"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <fontDescription key="fontDescription" type="boldSystem" pointSize="14"/>
-                                <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="GPIO #" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="a3Y-sY-eUF">
-                                <rect key="frame" x="273" y="72" width="49" height="21"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <fontDescription key="fontDescription" type="boldSystem" pointSize="14"/>
-                                <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>
-                                <nil key="highlightedColor"/>
-                            </label>
+                                    </tableView>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Wab-7D-0b6">
+                                        <rect key="frame" x="0.0" y="406" width="343" height="30"/>
+                                        <color key="backgroundColor" red="0.97019999999999995" green="0.97019999999999995" blue="0.98999999999999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                        <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="16"/>
+                                        <state key="normal" title="Show More Details">
+                                            <color key="titleColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>
+                                        </state>
+                                        <connections>
+                                            <action selector="onShowMoreDetails:" destination="eAF-Vh-bmA" eventType="touchUpInside" id="6A8-8c-IaN"/>
+                                        </connections>
+                                    </button>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="MkT-u4-tRs" userLabel="More Details">
+                                        <rect key="frame" x="0.0" y="436" width="343" height="350"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Remot3.it Account Name" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="m0V-Xr-drT">
+                                                <rect key="frame" x="16" y="8" width="168" height="17"/>
+                                                <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="14"/>
+                                                <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" restorationIdentifier="deviceAlias" text="myfriend@example.com" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="GiH-3B-yfU">
+                                                <rect key="frame" x="16" y="33" width="311" height="20.5"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Public IP Address" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9Jt-pD-Aub">
+                                                <rect key="frame" x="16" y="114.5" width="117.5" height="17"/>
+                                                <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="14"/>
+                                                <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" restorationIdentifier="deviceLastIP" text="78.45.xx.xx" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Fxo-nm-ncp">
+                                                <rect key="frame" x="16" y="139.5" width="311" height="20.5"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Private IP Address" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="kTk-if-vPB">
+                                                <rect key="frame" x="16" y="168.5" width="123.5" height="17"/>
+                                                <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="14"/>
+                                                <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" restorationIdentifier="deviceInternalIP" text="192.168.x.x" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="I71-46-W7M">
+                                                <rect key="frame" x="16" y="193.5" width="311" height="20.5"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Service Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ji7-SG-bMD">
+                                                <rect key="frame" x="16" y="222" width="84" height="17"/>
+                                                <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="14"/>
+                                                <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" restorationIdentifier="serviceTitle" text="Web browser" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="8PI-iP-f2O">
+                                                <rect key="frame" x="16" y="247" width="311" height="20.5"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="UID" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Pqq-zj-ztB">
+                                                <rect key="frame" x="16" y="275.5" width="25" height="17"/>
+                                                <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="14"/>
+                                                <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" restorationIdentifier="deviceAddress" text="80:00:00:00:05:56:00:3C:07" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="KaP-fg-WPy">
+                                                <rect key="frame" x="16" y="300.5" width="311" height="20.5"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Pin Layout" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="FIj-3m-one">
+                                                <rect key="frame" x="16" y="61" width="70.5" height="17"/>
+                                                <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="14"/>
+                                                <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" restorationIdentifier="layoutName" text="custom layout for device" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tx1-M5-1cq">
+                                                <rect key="frame" x="16" y="86" width="311" height="20.5"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                        </subviews>
+                                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                        <constraints>
+                                            <constraint firstItem="kTk-if-vPB" firstAttribute="leading" secondItem="m0V-Xr-drT" secondAttribute="leading" id="0N9-Z0-61Z"/>
+                                            <constraint firstItem="Pqq-zj-ztB" firstAttribute="leading" secondItem="ji7-SG-bMD" secondAttribute="leading" id="0fI-5W-HmG"/>
+                                            <constraint firstItem="m0V-Xr-drT" firstAttribute="leading" secondItem="MkT-u4-tRs" secondAttribute="leadingMargin" constant="8" id="10J-jN-ZcR"/>
+                                            <constraint firstAttribute="height" constant="350" id="7xA-JR-d4X"/>
+                                            <constraint firstItem="Pqq-zj-ztB" firstAttribute="top" secondItem="8PI-iP-f2O" secondAttribute="bottom" constant="8" id="EPH-S2-5Bi"/>
+                                            <constraint firstAttribute="trailingMargin" secondItem="KaP-fg-WPy" secondAttribute="trailing" constant="8" id="Ebf-tI-0P4"/>
+                                            <constraint firstItem="tx1-M5-1cq" firstAttribute="leading" secondItem="FIj-3m-one" secondAttribute="leading" id="FcG-JN-eAO"/>
+                                            <constraint firstItem="KaP-fg-WPy" firstAttribute="leading" secondItem="Pqq-zj-ztB" secondAttribute="leading" id="GG1-be-OzK"/>
+                                            <constraint firstItem="8PI-iP-f2O" firstAttribute="top" secondItem="ji7-SG-bMD" secondAttribute="bottom" constant="8" id="IwF-j2-ZBd"/>
+                                            <constraint firstItem="8PI-iP-f2O" firstAttribute="leading" secondItem="ji7-SG-bMD" secondAttribute="leading" id="MB0-kB-RDC"/>
+                                            <constraint firstItem="tx1-M5-1cq" firstAttribute="leading" secondItem="FIj-3m-one" secondAttribute="leading" id="Mr1-Lr-qQb"/>
+                                            <constraint firstItem="FIj-3m-one" firstAttribute="leading" secondItem="m0V-Xr-drT" secondAttribute="leading" id="Ueh-mo-aSS"/>
+                                            <constraint firstAttribute="trailingMargin" secondItem="I71-46-W7M" secondAttribute="trailing" constant="8" id="YkF-PY-FUA"/>
+                                            <constraint firstAttribute="trailingMargin" secondItem="GiH-3B-yfU" secondAttribute="trailing" constant="8" id="ZOj-02-BVr"/>
+                                            <constraint firstItem="kTk-if-vPB" firstAttribute="top" secondItem="Fxo-nm-ncp" secondAttribute="bottom" constant="8" id="aVO-zn-G3h"/>
+                                            <constraint firstItem="GiH-3B-yfU" firstAttribute="top" secondItem="m0V-Xr-drT" secondAttribute="bottom" constant="8" id="bOn-z8-d3s"/>
+                                            <constraint firstItem="m0V-Xr-drT" firstAttribute="top" secondItem="MkT-u4-tRs" secondAttribute="topMargin" id="bht-Ye-qrH"/>
+                                            <constraint firstItem="I71-46-W7M" firstAttribute="top" secondItem="kTk-if-vPB" secondAttribute="bottom" constant="8" id="d0Y-8R-W40"/>
+                                            <constraint firstAttribute="trailingMargin" secondItem="tx1-M5-1cq" secondAttribute="trailing" constant="8" id="dfM-4B-QY9"/>
+                                            <constraint firstAttribute="trailingMargin" secondItem="8PI-iP-f2O" secondAttribute="trailing" constant="8" id="emj-X9-Nsf"/>
+                                            <constraint firstItem="9Jt-pD-Aub" firstAttribute="leading" secondItem="m0V-Xr-drT" secondAttribute="leading" id="g6Q-yk-1a6"/>
+                                            <constraint firstItem="ji7-SG-bMD" firstAttribute="top" secondItem="I71-46-W7M" secondAttribute="bottom" constant="8" id="gHK-c6-hML"/>
+                                            <constraint firstItem="Fxo-nm-ncp" firstAttribute="top" secondItem="9Jt-pD-Aub" secondAttribute="bottom" constant="8" id="gt2-EB-QGX"/>
+                                            <constraint firstItem="I71-46-W7M" firstAttribute="leading" secondItem="kTk-if-vPB" secondAttribute="leading" id="ilr-T5-9AO"/>
+                                            <constraint firstItem="9Jt-pD-Aub" firstAttribute="top" secondItem="tx1-M5-1cq" secondAttribute="bottom" constant="8" id="ppq-ab-On7"/>
+                                            <constraint firstItem="GiH-3B-yfU" firstAttribute="leading" secondItem="m0V-Xr-drT" secondAttribute="leading" id="q92-4W-8GA"/>
+                                            <constraint firstItem="ji7-SG-bMD" firstAttribute="leading" secondItem="kTk-if-vPB" secondAttribute="leading" id="sL5-kY-mHz"/>
+                                            <constraint firstAttribute="trailingMargin" secondItem="Fxo-nm-ncp" secondAttribute="trailing" constant="8" id="tjT-x7-76a"/>
+                                            <constraint firstItem="FIj-3m-one" firstAttribute="top" secondItem="GiH-3B-yfU" secondAttribute="bottom" constant="8" id="uTi-CT-qCv"/>
+                                            <constraint firstItem="KaP-fg-WPy" firstAttribute="top" secondItem="Pqq-zj-ztB" secondAttribute="bottom" constant="8" id="vs4-wc-LkW"/>
+                                            <constraint firstItem="tx1-M5-1cq" firstAttribute="top" secondItem="FIj-3m-one" secondAttribute="bottom" constant="8" id="wZ8-cX-NI7"/>
+                                            <constraint firstItem="Fxo-nm-ncp" firstAttribute="leading" secondItem="9Jt-pD-Aub" secondAttribute="leading" id="yOv-c3-BbX"/>
+                                        </constraints>
+                                    </view>
+                                </subviews>
+                                <constraints>
+                                    <constraint firstItem="yU9-mF-1h1" firstAttribute="height" secondItem="srK-Hn-pQh" secondAttribute="height" id="cVc-PM-CMV"/>
+                                    <constraint firstItem="Wab-7D-0b6" firstAttribute="height" secondItem="yU9-mF-1h1" secondAttribute="height" id="vxe-je-6UK"/>
+                                </constraints>
+                            </stackView>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <constraints>
+                            <constraint firstAttribute="trailingMargin" secondItem="Xts-aI-bjy" secondAttribute="trailing" id="3Jy-if-dnz"/>
+                            <constraint firstItem="Xts-aI-bjy" firstAttribute="leading" secondItem="Jsw-CW-cDy" secondAttribute="leadingMargin" id="Kto-L8-L86"/>
+                            <constraint firstItem="Xts-aI-bjy" firstAttribute="top" secondItem="Nu5-Iw-R53" secondAttribute="bottom" id="gBe-nA-Q2j"/>
+                            <constraint firstItem="XSW-mF-0NZ" firstAttribute="top" secondItem="Xts-aI-bjy" secondAttribute="bottom" id="tEd-lW-TFO"/>
+                        </constraints>
                     </view>
                     <navigationItem key="navigationItem" title="Device Info" id="whv-7l-Vww"/>
                     <nil key="simulatedBottomBarMetrics"/>
+                    <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+                    <size key="freeformSize" width="375" height="850"/>
                     <connections>
-                        <outlet property="pinTable" destination="kOI-yq-mVd" id="M3V-kC-azv"/>
+                        <outlet property="lastUpdatedLabel" destination="Ooz-ko-dkM" id="dzY-Oq-hyL"/>
+                        <outlet property="powerStatusLabel" destination="j7c-xf-yfD" id="nig-2B-wPd"/>
+                        <outlet property="stackView" destination="Xts-aI-bjy" id="4lb-mo-yJM"/>
                         <segue destination="Bie-XA-VK0" kind="show" identifier="SHOW_DEVICE_SETUP" id="1Lx-Gl-rNf"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ded-zD-2KY" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="5334" y="-1016"/>
+            <point key="canvasLocation" x="4878" y="-1016"/>
         </scene>
     </scenes>
     <resources>
         <image name="LoginImg" width="24" height="24"/>
         <image name="checkbox-checked" width="24" height="24"/>
         <image name="checkbox-unchecked" width="24" height="24"/>
-        <image name="contrast" width="24" height="24"/>
         <image name="cross" width="24" height="24"/>
     </resources>
-    <inferredMetricsTieBreakers>
-        <segue reference="1Lx-Gl-rNf"/>
-    </inferredMetricsTieBreakers>
 </document>

--- a/PiRemote/PiRemote/DeviceSetupViewController.swift
+++ b/PiRemote/PiRemote/DeviceSetupViewController.swift
@@ -23,6 +23,10 @@ class DeviceSetupViewController: UIViewController, UIPopoverPresentationControll
         DeviceTypes.rPi3
         ].self
 
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
+
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         self.navigationController?.isNavigationBarHidden = false
@@ -31,8 +35,7 @@ class DeviceSetupViewController: UIViewController, UIPopoverPresentationControll
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        // TODO: Check if we should load from layout
-        pinLayout = PinLayout(name: "custom", defaultSetup: initPinSetup())
+        guard pinLayout != nil else { fatalError("[ERROR] No pin layout provided") }
 
         // Setting up navigation bar
         let backButton = UIBarButtonItem(title: "Back", style: .plain, target: self, action: #selector(DeviceSetupViewController.onLeave))

--- a/PiRemote/PiRemote/DeviceSetupViewController.swift
+++ b/PiRemote/PiRemote/DeviceSetupViewController.swift
@@ -79,7 +79,7 @@ class DeviceSetupViewController: UIViewController, UIPopoverPresentationControll
             contentSize = CGSize(width: 360, height: 700)
         case SegueTypes.idToPinSettings:
             let pin = sender as! Pin
-            contentSize = CGSize(width: 150, height: 250)
+            contentSize = CGSize(width: 150, height: 320)
             sourceRect = CGRect(origin: CGPoint(x: 0, y: 0), size: destination.view.bounds.size)
             (destination as! EditPinViewController).pin = pin
             destination.isEditing = self.navigationItem.rightBarButtonItem?.title == "Done"
@@ -163,20 +163,18 @@ class DeviceSetupViewController: UIViewController, UIPopoverPresentationControll
 
         let userInfo = notification.userInfo as! [String:String]
         let i = Int(userInfo["id"]!)! - 1
-        let name = userInfo["name"]
-        let type = userInfo["type"]
 
-        pinLayout.defaultSetup[i].name = name!
-
-        switch type! {
-        case "control":
-            pinLayout.defaultSetup[i].type = .control
-        case "ignore":
-            pinLayout.defaultSetup[i].type = .ignore
-        case "monitor":
-            pinLayout.defaultSetup[i].type = .monitor
-        default: break
+        var type: Pin.Types
+        switch userInfo["type"]! {
+        case "control": type = .control
+        case "ignore": type = .ignore
+        case "monitor": type = .monitor
+        default: type = .ignore
         }
+
+        pinLayout.defaultSetup[i].name = userInfo["name"]!
+        pinLayout.defaultSetup[i].type = type
+        pinLayout.defaultSetup[i].value = userInfo["value"]! == "true" ? 1 : 0
 
         scrollView.setPinData(pins: pinLayout.defaultSetup)
     }
@@ -218,21 +216,31 @@ class DeviceSetupViewController: UIViewController, UIPopoverPresentationControll
     }
 
     func onToggleEditDeviceSettings(sender: UIBarButtonItem!) {
+        var leftBtnTitle: String = "Error"
+        var rightBtnTitle: String = "Error"
+        var shouldHideToolbar: Bool = false
+
         switch sender.title! {
         case "Edit":
-            // Updating nav bar
-            self.navigationItem.leftBarButtonItem?.title = "Cancel"
-            self.navigationItem.rightBarButtonItem?.title = "Done"
-
-            DispatchQueue.main.async {
-                UIView.animate(withDuration: 0.25, delay: 0, options: .curveEaseOut, animations: {
-                    self.stackView.arrangedSubviews[1].isHidden = false
-                }, completion: nil)
-            }
+            leftBtnTitle = "Cancel"
+            rightBtnTitle = "Done"
+            shouldHideToolbar = false
         case "Done":
+            leftBtnTitle = "Back"
+            rightBtnTitle = "Edit"
+            shouldHideToolbar = true
             // TODO: Implement saving the layout
-            _ = self.navigationController?.popViewController(animated: true)
         default: break
+        }
+
+        // Updating nav bar
+        self.navigationItem.leftBarButtonItem?.title = leftBtnTitle
+        self.navigationItem.rightBarButtonItem?.title = rightBtnTitle
+
+        DispatchQueue.main.async {
+            UIView.animate(withDuration: 0.25, delay: 0, options: .curveEaseOut, animations: {
+                self.stackView.arrangedSubviews[1].isHidden = shouldHideToolbar
+            }, completion: nil)
         }
     }
 

--- a/PiRemote/PiRemote/EditPinViewController.swift
+++ b/PiRemote/PiRemote/EditPinViewController.swift
@@ -6,14 +6,6 @@
 //  Copyright © 2017 JLL Consulting. All rights reserved.
 //
 
-//
-//  PinSettingsViewController.swift
-//  PiRemote
-//
-//  Created by Muhammad Martinez on 4/2/17.
-//  Copyright © 2017 JLL Consulting. All rights reserved.
-//
-
 import UIKit
 
 class EditPinViewController: UIViewController {
@@ -23,10 +15,12 @@ class EditPinViewController: UIViewController {
     @IBOutlet weak var ignoreButton: UIButton!
     @IBOutlet weak var monitorButton: UIButton!
     @IBOutlet weak var nameBox: UITextField!
+    @IBOutlet weak var onOffLabel: UILabel!
+    @IBOutlet weak var onOffSwitch: UISwitch!
 
     // MARK: Local Variables
-    var pin: Pin!
 
+    var pin: Pin!
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -35,57 +29,72 @@ class EditPinViewController: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
 
+        // Styling based on initial pin data
         if !pin!.name.isEmpty {
             nameBox.text = pin!.name
         }
 
         header.text = "#" + String(describing: pin!.id)
+        onOffLabel.text = pin!.value == 1 ? "On" : "Off"
+        onOffSwitch.isOn = pin!.value == 1
+        onOffSwitch.isEnabled = isEditing
 
         switch pin!.type {
         case .control:
-            controlButton.backgroundColor = Theme.controlDarkColor
+            controlButton.backgroundColor = pin!.value == 1 ? Theme.lightGreen500 : Theme.amber500
             controlButton.setTitleColor(UIColor.white, for: .normal)
         case .monitor:
-            monitorButton.backgroundColor = Theme.monitorDarkColor
+            monitorButton.backgroundColor = Theme.cyan500
             monitorButton.setTitleColor(UIColor.white, for: .normal)
         case .ignore:
-            ignoreButton.backgroundColor = Theme.ignoreDarkColor
+            ignoreButton.backgroundColor = Theme.grey500
             ignoreButton.setTitleColor(UIColor.white, for: .normal)
         }
     }
 
-    @IBAction func onSelectControl(_ sender: UIButton) {
-        guard isEditing else { return }
-        handleTypeChange(type: "control")
-        sender.backgroundColor = Theme.controlDarkColor
-        sender.setTitleColor(UIColor.white, for: .normal)
-    }
+    // MARK: Local Functions
 
-    @IBAction func onSelectIgnore(_ sender: UIButton) {
+    @IBAction func onUpdateType(_ sender: UIButton) {
         guard isEditing else { return }
-        handleTypeChange(type: "ignore")
-        sender.backgroundColor = Theme.ignoreDarkColor
-        sender.setTitleColor(UIColor.white, for: .normal)
-    }
 
-    @IBAction func onSelectMonitor(_ sender: UIButton) {
-        guard isEditing else { return }
-        handleTypeChange(type: "monitor")
-        sender.backgroundColor = Theme.monitorDarkColor
-        sender.setTitleColor(UIColor.white, for: .normal)
-    }
-
-    func handleTypeChange(type: String) {
-        // Reset colors for buttons
+        let bgClr: UIColor
         let buttons = view.subviews.filter({vw in vw is UIButton}) as! [UIButton]
+        let type = sender.titleLabel!.text!.lowercased()
+
+        // Resetting button styles
         buttons.forEach({btn in
             btn.backgroundColor = UIColor.white
             btn.setTitleColor(UIColor.blue, for: .normal)
         })
 
-        NotificationCenter.default.post(
-            name: Notification.Name.updatePin,
-            object: self,
-            userInfo: ["id": String(pin!.id), "name": nameBox.text!, "type": String(describing: type)])
+        // Updating style for selected button
+        switch type {
+        case "control": bgClr = onOffSwitch.isOn ? Theme.lightGreen500 : Theme.amber500
+        case "monitor": bgClr = Theme.cyan500
+        case "ignore": bgClr = Theme.grey500
+        default: bgClr = UIColor.red
+        }
+
+        sender.backgroundColor = bgClr
+        sender.setTitleColor(UIColor.white, for: .normal)
+
+        // Notifying parent view controller to update pin data in layout
+        NotificationCenter.default.post(name: Notification.Name.updatePin, object: self, userInfo: [
+            "id": String(pin!.id), "name": nameBox.text!, "type": type, "value": String(onOffSwitch.isOn)])
+    }
+
+    @IBAction func onUpdateValue() {
+        guard isEditing else {
+            // Reverting action
+            onOffSwitch.isOn = !onOffSwitch.isOn
+            return
+        }
+        
+        onOffLabel.text = onOffSwitch.isOn ? "On" : "Off"
+        controlButton.backgroundColor = onOffSwitch.isOn ? Theme.lightGreen500 : Theme.amber500
+
+        // Notifying parent view controller to update pin data in layout
+        NotificationCenter.default.post(name: Notification.Name.updatePin, object: self, userInfo: [
+            "id": String(pin!.id), "name": pin!.name, "type": String(describing: pin!.type), "value": String(onOffSwitch.isOn)])
     }
 }

--- a/PiRemote/PiRemote/PiDiagramViewController.swift
+++ b/PiRemote/PiRemote/PiDiagramViewController.swift
@@ -1,0 +1,38 @@
+//
+//  PiDiagramViewController.swift
+//  PiRemote
+//
+//  Created by Muhammad Martinez on 4/11/17.
+//  Copyright © 2017 JLL Consulting. All rights reserved.
+//
+
+import UIKit
+
+class PiDiagramViewController: UIViewController {
+
+    @IBOutlet weak var header: UILabel!
+    @IBOutlet weak var imageView: UIImageView!
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        let diagram = UIImage(named: getFilePathToPinDiagram())
+
+        header.text = "Raspberry Pi 3"
+
+        // Order is important: resizes content after the image has been added to it.
+        imageView.image = diagram
+        imageView.contentMode = .scaleAspectFit
+    }
+
+    // MARK: Local Functions
+
+    @IBAction func onDismiss(_ sender: UIBarButtonItem) {
+        dismiss(animated: true, completion: nil)
+    }
+
+    func getFilePathToPinDiagram() -> String {
+        // Only supports Raspberry Pi 3 for now
+        return PiFilePaths.rPi3
+    }
+}

--- a/PiRemote/PiRemote/Pin.swift
+++ b/PiRemote/PiRemote/Pin.swift
@@ -16,6 +16,7 @@ class Pin: NSObject, NSCoding {
         case monitor = 2
     }
 
+    // TODO: Values like "ALT0", "ALT3", etc. are being saved as "IN". Should we be doing this?
     var _function: String = "IN"
     var function: String {
         get {

--- a/PiRemote/PiRemote/PinSetupScrollView.swift
+++ b/PiRemote/PiRemote/PinSetupScrollView.swift
@@ -95,17 +95,17 @@ class PinSetupScrollView: UIScrollView {
 
             switch pins[i - 1].type {
             case .ignore:
-                btn.backgroundColor = Theme.ignoreLightColor
-                btn.layer.borderColor = Theme.ignoreDarkColor.cgColor
+                btn.backgroundColor = Theme.grey300
+                btn.layer.borderColor = Theme.grey500.cgColor
             case .monitor:
-                btn.backgroundColor = Theme.monitorLightColor
-                btn.layer.borderColor = Theme.monitorDarkColor.cgColor
+                btn.backgroundColor = Theme.cyan300
+                btn.layer.borderColor = Theme.cyan500.cgColor
             case .control:
-                btn.backgroundColor = Theme.controlLightColor
-                btn.layer.borderColor = Theme.controlDarkColor.cgColor
+                btn.backgroundColor = pins[i - 1].value == 1 ? Theme.lightGreen300 : Theme.amber300
+                btn.layer.borderColor = pins[i - 1].value == 1 ? Theme.lightGreen500.cgColor : Theme.amber500.cgColor
             }
 
-            btn.setTitleColor(Theme.pinButtonTextColor, for: UIControlState.normal)
+            btn.setTitleColor(Theme.grey900, for: UIControlState.normal)
         }
         setNeedsDisplay()
     }

--- a/PiRemote/PiRemote/PinTableViewCell.swift
+++ b/PiRemote/PiRemote/PinTableViewCell.swift
@@ -2,21 +2,64 @@
 //  PinTableViewCell.swift
 //  PiRemote
 //
-//  Authors: Hunter Heard, Josh Binkley
-//  Copyright (c) 2016 JLL Consulting. All rights reserved.
+//  Authors: Muhammad Martinez
+//  Copyright (c) 2017 JLL Consulting. All rights reserved.
 //
 
 import UIKit
 
 class PinTableViewCell: UITableViewCell {
 
-    @IBOutlet weak var nameLabel: UILabel!
-    @IBOutlet weak var numberLabel: UILabel!
-    @IBOutlet weak var statusSwitch: UISwitch!
+    @IBOutlet weak var pinNameLabel: UILabel!
+    @IBOutlet weak var pinView: UIButton!
     @IBOutlet weak var typeLabel: UILabel!
+    @IBOutlet weak var valueSwitch: UISwitch!
 
-    override func awakeFromNib() {
-        super.awakeFromNib()
-        // Initialization code
+    required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+    }
+
+    // MARK: Local Functions
+
+    @IBAction func onToggleSwitch(_ sender: UISwitch) {
+        // Notifying parent view controller to update pin data in layout
+        NotificationCenter.default.post(name: Notification.Name.updatePin, object: self, userInfo: [
+            "id": String(pinView.tag), "value": String(sender.isOn)])
+    }
+
+    func updateStyle(with pin: Pin) {
+        pinNameLabel.text = pin.name
+
+        pinView.layer.borderWidth = 4.0
+        pinView.layer.cornerRadius = 8.0
+        pinView.setTitle("\(pin.id)", for: UIControlState.normal)
+        pinView.tag = pin.id
+        pinView.titleLabel?.font = UIFont.boldSystemFont(ofSize: 32.0)
+
+        // Capitalzing first letter of type
+        var typeFormatted = String(describing: pin.type)
+        typeFormatted = String(typeFormatted.characters.prefix(1)).uppercased() + String(typeFormatted.characters.dropFirst())
+        typeLabel.text = typeFormatted
+
+        valueSwitch.isOn = pin.value == 1
+        valueSwitch.isEnabled = pin.type == .control
+
+        var bgClr: UIColor
+        var borderClr: CGColor
+        switch pin.type {
+        case .ignore:
+            bgClr = Theme.grey300
+            borderClr = Theme.grey500.cgColor
+        case .monitor:
+            bgClr = Theme.cyan300
+            borderClr = Theme.cyan500.cgColor
+        case .control:
+            bgClr = pin.value == 1 ? Theme.lightGreen300 : Theme.amber300
+            borderClr = pin.value == 1 ? Theme.lightGreen500.cgColor : Theme.amber500.cgColor
+        }
+
+        pinView.backgroundColor = bgClr
+        pinView.layer.borderColor = borderClr
+        pinView.setTitleColor(Theme.grey900, for: UIControlState.normal)
     }
 }

--- a/PiRemote/PiRemote/PopoverViewController.swift
+++ b/PiRemote/PiRemote/PopoverViewController.swift
@@ -55,18 +55,15 @@ class PopoverViewController: UIViewController {
 
         // TODO: Update subviews based on picker value in DeviceSetup
         let imageView = self.view.subviews.filter({vw in vw is UIImageView}).first as! UIImageView
-        let label = self.view.subviews.filter({vw in vw is UILabel}).first as! UILabel
 
         // Order is important: resizes content after the image has been added to it.
         imageView.image = diagram
         imageView.contentMode = .scaleAspectFit
-
-        label.text = "Raspberry Pi 3"
     }
 
     func getFilePathToPinDiagram() -> String {
         // Only supports Raspberry Pi 3
-        return PinGuideFilePaths.rPi3
+        return PiFilePaths.rPi3
     }
 
     // MARK: Utility Functions

--- a/PiRemote/PiRemote/RemoteDevice.swift
+++ b/PiRemote/PiRemote/RemoteDevice.swift
@@ -10,15 +10,12 @@ import Foundation
 
 class RemoteDevice: NSObject, NSCoding {
 
-    
-
     // Descriptions can be found at http://docs.weaved.com/docs/devicelistall
     var apiData: [String: String]!
 
     // Local Variables
     var layout: PinLayout!
     var shouldPersistState: Bool! // Attempt to restore previous pin values on restart
-    var stateJson: [String: [String:AnyObject]]!
 
     override init() {
         super.init()
@@ -28,7 +25,6 @@ class RemoteDevice: NSObject, NSCoding {
         self.apiData = decoder.decodeObject(forKey: "apiData") as! [String:String]
         self.layout = decoder.decodeObject(forKey: "layout") as! PinLayout
         self.shouldPersistState = decoder.decodeObject(forKey: "shouldPersistState") as! Bool
-        self.stateJson = decoder.decodeObject(forKey: "stateJson") as! [String: [String:AnyObject]]
     }
 
     init(deviceData: NSDictionary) {
@@ -49,6 +45,5 @@ class RemoteDevice: NSObject, NSCoding {
         coder.encode(apiData, forKey: "apiData")
         coder.encode(layout, forKey: "layout")
         coder.encode(shouldPersistState, forKey: "shouldPersistState")
-        coder.encode(stateJson, forKey: "stateJson")
     }
 }

--- a/PiRemote/PiRemote/SysConstants.swift
+++ b/PiRemote/PiRemote/SysConstants.swift
@@ -25,6 +25,8 @@ struct Theme {
     static let grey900 = UIColor(red: 0x21 / 255, green: 0x21 / 255, blue: 0x21 / 255, alpha: 1.0)
     static let lightGreen300 = UIColor(red: 0xae / 255, green: 0xd5 / 255, blue: 0x81 / 255, alpha: 1.0)
     static let lightGreen500 = UIColor(red: 0x8b / 255, green: 0xc3 / 255, blue: 0x4a / 255, alpha: 1.0)
+    static let red300 = UIColor(red: 0xe5 / 255, green: 0x73 / 255, blue: 0x73 / 255, alpha: 1.0)
+    static let red500 = UIColor(red: 0xf4 / 255, green: 0x43 / 255, blue: 0x36 / 255, alpha: 1.0)
 }
 
 struct DeviceTypes {

--- a/PiRemote/PiRemote/SysConstants.swift
+++ b/PiRemote/PiRemote/SysConstants.swift
@@ -15,13 +15,16 @@ struct AppEngineConstants {
 }
 
 struct Theme {
-    static let controlDarkColor = UIColor(red: 0xff / 255, green: 0xc1 / 255, blue: 0x07 / 255, alpha: 1.0)
-    static let controlLightColor = UIColor(red: 0xff / 255, green: 0xd5 / 255, blue: 0x4f / 255, alpha: 1.0)
-    static let ignoreDarkColor = UIColor(red: 0x9e / 255, green: 0x9e / 255, blue: 0x9e / 255, alpha: 1.0)
-    static let ignoreLightColor = UIColor(red: 0xe0 / 255, green: 0xe0 / 255, blue: 0xe0 / 255, alpha: 1.0)
-    static let monitorDarkColor = UIColor(red: 0x00 / 255, green: 0xbc / 255, blue: 0xd4 / 255, alpha: 1.0)
-    static let monitorLightColor = UIColor(red: 0x4d / 255, green: 0xd0 / 255, blue: 0xe1 / 255, alpha: 1.0)
-    static let pinButtonTextColor = UIColor(red: 0x21 / 255, green: 0x21 / 255, blue: 0x21 / 255, alpha: 1.0)
+    // https://material.io/guidelines/style/color.html#color-color-palette
+    static let amber300 = UIColor(red: 0xff / 255, green: 0xd5 / 255, blue: 0x4f / 255, alpha: 1.0)
+    static let amber500 = UIColor(red: 0xff / 255, green: 0xc1 / 255, blue: 0x07 / 255, alpha: 1.0)
+    static let cyan300 = UIColor(red: 0x4d / 255, green: 0xd0 / 255, blue: 0xe1 / 255, alpha: 1.0)
+    static let cyan500 = UIColor(red: 0x00 / 255, green: 0xbc / 255, blue: 0xd4 / 255, alpha: 1.0)
+    static let grey300 = UIColor(red: 0xe0 / 255, green: 0xe0 / 255, blue: 0xe0 / 255, alpha: 1.0)
+    static let grey500 = UIColor(red: 0x9e / 255, green: 0x9e / 255, blue: 0x9e / 255, alpha: 1.0)
+    static let grey900 = UIColor(red: 0x21 / 255, green: 0x21 / 255, blue: 0x21 / 255, alpha: 1.0)
+    static let lightGreen300 = UIColor(red: 0xae / 255, green: 0xd5 / 255, blue: 0x81 / 255, alpha: 1.0)
+    static let lightGreen500 = UIColor(red: 0x8b / 255, green: 0xc3 / 255, blue: 0x4a / 255, alpha: 1.0)
 }
 
 struct DeviceTypes {
@@ -35,10 +38,8 @@ struct DeviceTypes {
 }
 
 // TODO: Add pinout images for remaining flavors of pi
-struct PinGuideFilePaths {
-    static let rPi1B = "Raspberry-Pi-Pinouts-Model-B-Rev-1"     // @1x: 356 x 700
-    static let rPi2 = "Raspberry-Pi-Pinouts-Model-B-A_B-Rev-2"  // @1x: 356 x 700
-    static let rPi3 = "Raspberry-Pi-Pinouts-Model-B-Plus"       // @1x: 356 x 732
+struct PiFilePaths {
+    static let rPi3 = "RaspberryPi_3B"
 }
 
 extension Notification.Name {


### PR DESCRIPTION
- Uses `UIStackView` to better organize device data
- Passes device data to `DeviceSetupViewController`
- Pin TableView is showing all _53_ pins returned from WebIOPi's [`/* endpoint`](http://webiopi.trouch.com/RESTAPI.html#get-full-gpio-state-configuration), but the Raspberry Pi 3 only has _40_...?

**Before (storyboard)**
![image](https://cloud.githubusercontent.com/assets/5534079/25015512/b0852ee2-2041-11e7-9140-14bb392f8a7b.png)

**After**
- Pins are not named in this example
- UI bug for show/hide more details label has been noted
![device-info-vc](https://cloud.githubusercontent.com/assets/5534079/25015351/08dcf7c4-2041-11e7-9b8a-f908f9d3f319.gif)